### PR TITLE
Python 3 compatibility

### DIFF
--- a/pif_csv_utils/general.py
+++ b/pif_csv_utils/general.py
@@ -38,16 +38,20 @@ def decode_string(string):
     :return: decoded string
     """
 
-    # string = string.replace('\xef\xbb\xbf', '')
     try:
-        string = string.decode('utf-8').encode('utf-8')
-    except UnicodeDecodeError:
+        # string = string.replace('\xef\xbb\xbf', '')
         try:
-            string = string.decode('latin-1').encode('utf-8')
+            string = string.decode('utf-8').encode('utf-8')
         except UnicodeDecodeError:
             try:
-                string = str(string).decode('mac-roman').encode('utf-8')
+                string = string.decode('latin-1').encode('utf-8')
             except UnicodeDecodeError:
-                sys.exit('Unable to parse this file as the encoding is not recognized.\n')
+                try:
+                    string = str(string).decode('mac-roman').encode('utf-8')
+                except UnicodeDecodeError:
+                    sys.exit('Unable to parse this file as the encoding is not recognized.\n')
+    except AttributeError:
+        # str.decode() does not exist in Python 3, but str is always Unicode
+        pass
 
     return string


### PR DESCRIPTION
Python 3 strings are Unicode by default, so explicitly decoding and encoding them is not necessary (and also not possible because `.decode()` does not exist for strings). This is the only Python 3 incompatibility I've found for this package using the tests.