### PR TITLE
Replace sys.exit() calls with raising exceptions

### DIFF
--- a/csv_template_ingester/converter.py
+++ b/csv_template_ingester/converter.py
@@ -24,7 +24,7 @@ def _check_table_size(table, cell_limit=100 * 100000 + 1):
             pif_count += 1
 
         if pif_count * col_count > cell_limit:
-            sys.exit(
+            raise ValueError(
                 'This ingester only supports up to {} cells (rows * columns).\nPlease split your file into smaller files and ingest each separately'.format(
                     cell_limit))
 
@@ -80,7 +80,7 @@ def convert(files=[], **kwargs):
                 table = get_data_from_tsv(input_file)
 
             else:
-                sys.exit('Filetype provided is not compatible with this parser. Please upload a .csv or .tsv file.\n')
+                raise IOError('Filetype provided is not compatible with this parser. Please upload a .csv or .tsv file.\n')
 
             if not _check_table_size(table, (100 * 100000 + 1)):
                 continue

--- a/csv_template_ingester/template_csv_parser.py
+++ b/csv_template_ingester/template_csv_parser.py
@@ -60,7 +60,7 @@ def get_keyword(column_header):
 
     if ':' in column_header:
         if column_header.count(':') > 2:
-            sys.exit(
+            raise ValueError(
                 'Header cells should contain a maximum of one colon (:) to separate the keyword from the column name.\n')
         keyword = column_header.split(':')[0]
         column_header = column_header.split(':')[1]
@@ -258,7 +258,7 @@ def add_fields(keywords, names, units, systs, sys_dict, row):
             unknown += ', %s' % j
 
     if any(unknown):
-        sys.stdout.write('Unknown header(s) for column(s) %s.\n' % (unknown[1:]))
+        print ('Unknown header(s) for column(s) %s.\n' % (unknown[1:]))
 
     return sys_dict, all_condition
 
@@ -364,7 +364,7 @@ def add_actual_composition(systm, composition_value, names, units, column_index)
         if names[column_index]:
             comp.element = names[column_index]
         else:
-            sys.exit('No element has been specified in column: %s' % column_index)
+            raise ValueError('No element has been specified in column: %s' % column_index)
 
         if 'atomic' in units[column_index] or 'at' in units[column_index]:
             comp.actual_atomic_percent = composition_value
@@ -373,7 +373,7 @@ def add_actual_composition(systm, composition_value, names, units, column_index)
             comp.actual_weight_percent = composition_value
 
         else:
-            sys.exit('Please specify atomic or weight percent for the composition in column: %s\n' % column_index)
+            raise ValueError('Please specify atomic or weight percent for the composition in column: %s\n' % column_index)
 
         if systm.composition:
             systm.composition = listify(systm.composition)
@@ -403,7 +403,7 @@ def add_ideal_composition(systm, composition_value, names, units, column_index):
         if names[column_index]:
             comp.element = names[column_index]
         else:
-            sys.exit('No element has been specified in column: %s' % column_index)
+            raise ValueError('No element has been specified in column: %s' % column_index)
 
         if 'atomic' in units[column_index] or 'at' in units[column_index]:
             comp.ideal_atomic_percent = composition_value
@@ -412,7 +412,7 @@ def add_ideal_composition(systm, composition_value, names, units, column_index):
             comp.ideal_weight_percent = composition_value
 
         else:
-            sys.exit('Please specify atomic or weight percent for the composition in column: %s\n' % column_index)
+            raise ValueError('Please specify atomic or weight percent for the composition in column: %s\n' % column_index)
 
         if systm.composition:
             systm.composition = listify(systm.composition)
@@ -448,7 +448,7 @@ def add_ideal_quantity(systm, quantity_value, units, column_index):
             quant.ideal_number_percent = Scalar(value=quantity_value)
 
         else:
-            sys.exit('Please specify mass, volume or number percent for the quantity in column: %s\n' % column_index)
+            raise ValueError('Please specify mass, volume or number percent for the quantity in column: %s\n' % column_index)
 
         systm.quantity = quant
 
@@ -480,7 +480,7 @@ def add_actual_quantity(systm, quantity_value, units, column_index):
             quant.actual_number_percent = Scalar(value=quantity_value)
 
         else:
-            sys.exit('Please specify mass, volume or number percent for the quantity in column: %s\n' % column_index)
+            raise ValueError('Please specify mass, volume or number percent for the quantity in column: %s\n' % column_index)
 
         systm.quantity = quant
 
@@ -502,7 +502,7 @@ def add_newfile(systm, file_name, names, column_index):
     if names[column_index]:
         prop.name = names[column_index]
     else:
-        sys.exit(
+        raise ValueError(
             'No file name has been specified for column: %s. Every files column must have a name provided in the header row.\n' % (
                 column_index + 1))
 
@@ -538,7 +538,7 @@ def add_property(systm, property_value, names, units, column_index):
     if names[column_index]:
         prop.name = names[column_index]
     else:
-        sys.exit(
+        raise ValueError(
             'No property name has been specified for column: %s. Every property column must have a name provided in the header row.\n' % (
                 column_index + 1))
 
@@ -575,7 +575,7 @@ def add_preparation_step_detail(systm, preparation_step_detail, names, units, co
         if systm.preparation:
             step = systm.preparation[-1]
         else:
-            sys.exit(
+            raise ValueError(
                 'Preparation details were provided before a step name was given. A preparation step name must always be provided to the left of the details columns.\n')
 
         if step.details:
@@ -587,7 +587,7 @@ def add_preparation_step_detail(systm, preparation_step_detail, names, units, co
         if names[column_index]:
             detail.name = names[column_index]
         else:
-            sys.exit(
+            raise ValueError(
                 'No preparation step detail name has been specified for column: %s. Preparation step details mst have a name specified in the header row.\n' % (
                     column_index + 1))
 
@@ -620,7 +620,7 @@ def add_condition(systm, condition, names, units, column_index):
         if systm.properties:
             prop = systm.properties[-1]
         else:
-            sys.exit(
+            raise ValueError(
                 'Condition details were provided before a property was given. Condition columns must appear to the right of the property that they belong to.\n')
 
         if prop.conditions:
@@ -632,7 +632,7 @@ def add_condition(systm, condition, names, units, column_index):
         if names[column_index]:
             conditions.name = names[column_index]
         else:
-            sys.exit(
+            raise ValueError(
                 'No condition name has been specified for column: %s. Conditions must have a name specified in the header row.\n' % (
                     column_index + 1))
 

--- a/pif_csv_utils/general.py
+++ b/pif_csv_utils/general.py
@@ -1,5 +1,4 @@
 import re
-import sys
 
 
 def normalize(string):
@@ -49,7 +48,7 @@ def decode_string(string):
                 try:
                     string = str(string).decode('mac-roman').encode('utf-8')
                 except UnicodeDecodeError:
-                    sys.exit('Unable to parse this file as the encoding is not recognized.\n')
+                    raise IOError('Unable to parse this file as the encoding is not recognized.')
     except AttributeError:
         # str.decode() does not exist in Python 3, but str is always Unicode
         pass

--- a/pif_csv_utils/pif_utils.py
+++ b/pif_csv_utils/pif_utils.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 from pypif.obj import *
 from pif_csv_utils.general import *
-import sys
 
 
 def add_uid(systm, uid):
@@ -14,10 +13,10 @@ def add_uid(systm, uid):
     """
 
     if systm.uid:
-        sys.exit(
+        raise ValueError(
             'You are attempting to add a UID to a system that already has one. Each system can only have 1 UID.\n')
     elif isinstance(uid, list):
-        sys.exit('You are trying to add multiple UIDs to a system. Each ChemicalSystem can only have 1 UID')
+        raise ValueError('You are trying to add multiple UIDs to a system. Each ChemicalSystem can only have 1 UID')
     elif uid:
         systm.uid = re.sub(r'\W', '', uid)
         print ('UIDs manually added. If two systems have the same then one will be overwritten by the information in the other. Please make sure all UIDs are unique.')
@@ -34,13 +33,13 @@ def add_formula(systm, formula):
     :return: system updated with the formula info
     """
     if not isinstance(systm, ChemicalSystem):
-        sys.exit('A chemical formula can only be added to a ChemicalSystem')
+        raise TypeError('A chemical formula can only be added to a ChemicalSystem')
 
     if systm.chemical_formula:
-        sys.exit(
+        raise ValueError(
             'You are attempting to add a chemical formula to a system that already has one. Each ChemicalSystem can only have 1 formula.\n')
     elif isinstance(formula, list):
-        sys.exit('You are trying to add multiple formulas to a system. Each ChemicalSystem can only have 1 formula')
+        raise ValueError('You are trying to add multiple formulas to a system. Each ChemicalSystem can only have 1 formula')
     elif formula:
         systm.chemical_formula = formula
 
@@ -81,7 +80,7 @@ def add_method(systm, method_value):
         if systm.properties:
             prop = systm.properties[-1]
         else:
-            sys.exit(
+            raise ValueError(
                 'Method details provided before a property was specified. Method columns must appear to the right of the property they belong to.\n')
 
         if prop.methods:
@@ -113,7 +112,7 @@ def add_number(systm, number_value, source_type):
         if systm.properties:
             prop = systm.properties[-1]
         else:
-            sys.exit(
+            raise ValueError(
                 'Number details provided before a property was specified. Number columns must appear to the right of the property they belong to.\n')
 
         if prop.references:
@@ -148,7 +147,7 @@ def add_caption(systm, caption_value, source_type):
         if systm.properties:
             prop = systm.properties[-1]
         else:
-            sys.exit(
+            raise ValueError(
                 'Caption details provided before a property was specified. Caption columns must appear to the right of the property they belong to.\n')
 
         if prop.references:
@@ -184,7 +183,7 @@ def add_datatype(systm, datatype):
         if systm.properties:
             prop = systm.properties[-1]
         else:
-            sys.exit(
+            raise ValueError(
                 'Data type provided before a property was specified. Data type columns must appear to the right of the property that they belong to.\n')
 
         prop.data_type = datatype


### PR DESCRIPTION
`sys.exit()` raises a `SystemExit` exception, which does not inherit from `Exception` and is therefore not commonly caught. Changing `sys.exit()` calls to `raise ...` statements makes this package play more nicely with other scripts.

Most of the exceptions raised are `ValueError`s, which may or may not be the most appropriate exception type (please review).